### PR TITLE
fix: Repository typo in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@preact/playwright-ct",
   "version": "0.0.2",
   "description": "Playwright Component Testing for Preact",
-  "repository": "github:preact/playwright-ct",
+  "repository": "github:preactjs/playwright-ct",
   "keywords": [
     "Preact",
     "Playwright",


### PR DESCRIPTION
Link on NPM 404s