### PR TITLE
test(ct): component features

### DIFF
--- a/tests/components/Button.tsx
+++ b/tests/components/Button.tsx
@@ -1,0 +1,11 @@
+type ButtonProps = {
+  title: string;
+  onClick?(props: string): void;
+  className?: string;
+};
+
+export function Button({ onClick, title, ...attributes }: ButtonProps) {
+  return <button {...attributes} onClick={() => onClick?.('hello')}>
+    {title}
+  </button>
+}

--- a/tests/components/Counter.tsx
+++ b/tests/components/Counter.tsx
@@ -1,0 +1,18 @@
+import { useRef } from "preact/hooks"
+
+type CounterProps = {
+  count?: number;
+  onClick?(props: string): void;
+  children?: any;
+}
+
+let _remountCount = 1;
+
+export function Counter(props: CounterProps) {
+  const remountCount = useRef(_remountCount++);
+  return <div onClick={() => props.onClick?.('hello')}>
+    <div id="props">{ props.count }</div>
+    <div id="remount-count">{ remountCount.current }</div>
+    { props.children }
+  </div>
+}

--- a/tests/components/DefaultChildren.tsx
+++ b/tests/components/DefaultChildren.tsx
@@ -1,0 +1,15 @@
+type DefaultChildrenProps = {
+  children?: any;
+}
+
+export function DefaultChildren(props: DefaultChildrenProps) {
+  return <div>
+    <h1>Welcome!</h1>
+    <main>
+      {props.children}
+    </main>
+    <footer>
+      Thanks for visiting.
+    </footer>
+  </div>
+}

--- a/tests/components/EmptyFragment.tsx
+++ b/tests/components/EmptyFragment.tsx
@@ -1,0 +1,3 @@
+export function EmptyFragment() {
+  return <>{[]}</>;
+}

--- a/tests/components/MultiRoot.tsx
+++ b/tests/components/MultiRoot.tsx
@@ -1,0 +1,6 @@
+export function MultiRoot() {
+  return <>
+    <div>root 1</div>
+    <div>root 2</div>
+  </>
+}

--- a/tests/preact.test.tsx
+++ b/tests/preact.test.tsx
@@ -1,7 +1,115 @@
 import { test, expect } from "../src/index";
-import { App } from "./App";
+import { Button } from './components/Button';
+import { DefaultChildren } from './components/DefaultChildren';
+import { MultiRoot } from './components/MultiRoot';
+import { Counter } from './components/Counter';
+import { EmptyFragment } from './components/EmptyFragment';
 
-test("should render component", async ({ mount }) => {
-  const component = await mount(<App />);
-  await expect(component).toContainText("foo");
+test('render props', async ({ mount }) => {
+  const component = await mount(<Button title="Submit" />);
+  await expect(component).toContainText('Submit');
+});
+
+test('render attributes', async ({ mount }) => {
+  const component = await mount(<Button className="primary" title="Submit" />);
+  await expect(component).toHaveClass('primary');
+});
+
+test('update props without remounting', async ({ mount }) => {
+  const component = await mount(<Counter count={9001} />);
+  await expect(component.locator('#props')).toContainText('9001');
+
+  await component.update(<Counter count={1337} />);
+  await expect(component).not.toContainText('9001');
+  await expect(component.locator('#props')).toContainText('1337');
+
+  await expect(component.locator('#remount-count')).toContainText('1');
+})
+
+test('update callbacks without remounting', async ({ mount }) => {
+  const component = await mount(<Counter />);
+
+  const messages: string[] = [];
+  await component.update(<Counter onClick={message => {
+    messages.push(message)
+  }} />);
+  await component.click();
+  expect(messages).toEqual(['hello']);
+
+  await expect(component.locator('#remount-count')).toContainText('1');
+})
+
+test('update slots without remounting', async ({ mount }) => {
+  const component = await mount(<Counter>Default Slot</Counter>);
+  await expect(component).toContainText('Default Slot');
+
+  await component.update(<Counter>Test Slot</Counter>);
+  await expect(component).not.toContainText('Default Slot');
+  await expect(component).toContainText('Test Slot');
+
+  await expect(component.locator('#remount-count')).toContainText('1');
+;})
+
+test('execute callback when the button is clicked', async ({ mount }) => {
+  const messages: string[] = [];
+  const component = await mount(<Button title="Submit" onClick={data => {
+    messages.push(data)
+  }}></Button>);
+  await component.click();
+  expect(messages).toEqual(['hello']);
+});
+
+test('render a default child', async ({ mount }) => {
+  const component = await mount(<DefaultChildren>
+    Main Content
+  </DefaultChildren>)
+  await expect(component).toContainText('Main Content')
+});
+
+test('render a component as slot', async ({ mount }) => {
+  const component = await mount(<DefaultChildren>
+    <Button title="Submit" />
+  </DefaultChildren>)
+  await expect(component).toContainText('Submit')
+});
+
+test('render multiple children', async ({ mount }) => {
+  const component = await mount(<DefaultChildren>
+    <div id="one">One</div>
+    <div id="two">Two</div>
+  </DefaultChildren>)
+  await expect(component.locator('#one')).toContainText('One')
+  await expect(component.locator('#two')).toContainText('Two')
+});
+
+test('execute callback when a child node is clicked', async ({ mount }) => {
+  let clickFired = false;
+  const component = await mount(<DefaultChildren>
+    <span onClick={() => clickFired = true}>Main Content</span>
+  </DefaultChildren>);
+  await component.locator('text=Main Content').click();
+  expect(clickFired).toBeTruthy();
+});
+
+test('unmount', async ({ page, mount }) => {
+  const component = await mount(<Button title="Submit" />)
+  await expect(page.locator('#root')).toContainText('Submit')
+  await component.unmount();
+  await expect(page.locator('#root')).not.toContainText('Submit');
+});
+
+test('unmount a multi root component', async ({ mount, page }) => {
+  const component = await mount(<MultiRoot />);
+  await expect(page.locator('#root')).toContainText('root 1');
+  await expect(page.locator('#root')).toContainText('root 2');
+  await component.unmount();
+  await expect(page.locator('#root')).not.toContainText('root 1');
+  await expect(page.locator('#root')).not.toContainText('root 2');
+});
+
+test('get textContent of the empty fragment', async ({ mount }) => {
+  const component = await mount(<EmptyFragment />);
+  expect(await component.allTextContents()).toEqual(['']);
+  expect(await component.textContent()).toBe('');
+  await expect(component).toHaveText('');
 });


### PR DESCRIPTION
Current version seems to work quite well already!:) Applied of most React's test suite: https://github.com/microsoft/playwright/blob/main/tests/components/ct-react-vite/src/tests.spec.tsx

Only the `beforeMount` and `afterMount` hooks are missing: https://github.com/microsoft/playwright/pull/18616. Shall i take a look at that?

Maybe we can change the project structure to that of Playwright? With a separate adapter project: 
https://github.com/microsoft/playwright/tree/main/packages/playwright-ct-react

And a separate test project:
https://github.com/microsoft/playwright/blob/main/tests/components/ct-react-vite

