### PR TITLE
chore: update peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "@playwright/test": "1.x",
+    "@playwright/test": ">=1.28.0",
     "preact": "10.x"
   },
   "devDependencies": {


### PR DESCRIPTION
At least v1.28 is required. `window.playwrightUpdate` was introduced in that version.